### PR TITLE
Allow question mark inside sentences

### DIFF
--- a/tatarin/question_handler.py
+++ b/tatarin/question_handler.py
@@ -13,7 +13,7 @@ def _is_question(data):
     msg = data['text']
     msg_lower = msg.lower().rstrip()
 
-    if not msg_lower.endswith('?'):
+    if not (msg_lower.endswith('?') or '? ' in msg_lower):
         return False
 
     if is_bot_mention(data):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -16,7 +16,7 @@ class TestQuestions(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        tatarin.bot.BOT_ID = cls.BOT_ID
+        tatarin.BOT_ID = cls.BOT_ID
         conn = me.connect('mongoenginetest', host='mongomock://localhost')
         cls.MONGO_MOCK: DatabaseStore = conn.mongoenginetest
         cls.MONGO_MOCK.create_collection(cls.COLLECTION)

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -46,3 +46,18 @@ class TestQuestions(unittest.TestCase):
         assert reply, "Reply isn't empty"
     
         assert Questions.objects(text__exists=True).count() == 1
+
+    def test_trailing_sentence(self):
+        assert Questions.objects(text__exists=True).count() == 0
+    
+        message = "<@{}> Росновский, когда подкаст? Опять до последнего тянешь!".format(self.BOT_ID)
+    
+        data = {"client_msg_id": "0ebe05ca-a41f-4174-8d19-0a3e34b0e0d5", "suppress_notification": False,
+            "text": message, "user": "U36UPATB6", "team": "T37A8AJBZ", "user_team": "T37A8AJBZ",
+            "source_team": "T37A8AJBZ", "channel": "C4V5A0E3W", "event_ts": "1572364286.379400",
+            "ts": "1572364286.379400"}
+    
+        reply = message_event(event=data)
+        assert reply, "Reply isn't empty"
+
+        assert Questions.objects(text__exists=True).count() == 1


### PR DESCRIPTION
Currently Tatarin requires questions to end with a `?`. This does not allow users to add more context after the question, e.g. a phrase like "How do you do fellow kids? Today is such a lovely weather!" will not be stored.

With these changes bot will recognize any phrase that contains at least one sentence with a question.

And I also fixed failing tests :virtim: